### PR TITLE
Return result of endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
-# hello
+# koa-router-fp-ts
 
-to set this up
+A WIP new router for `koa` that uses `io-ts` validators to check input before
+running to ensure validation is pushed to the very border of your application.
+
+Somewhat inspired by `Servant`.
+
+## Development install
 
 ```
 yarn install
 
-yarn ts-node src/index.ts
+# check those types
+yarn typescript:watch
+
+# run those tests
+yarn test:watch
 ```

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -56,7 +56,7 @@ const healthz = routeWithHandler(
 
 describe('Testing with koa', () => {
   it('Returns a 404 when no routes are found', async () => {
-    await withServer(router(healthz), async server => {
+    await withServer(router(healthz), async (server) => {
       const reply = await request(server)
         .get('/')
         .expect(404)
@@ -66,7 +66,7 @@ describe('Testing with koa', () => {
   })
 
   it('Returns a 404 when method does not match for healthz route', async () => {
-    await withServer(router(healthz), async server => {
+    await withServer(router(healthz), async (server) => {
       const reply = await request(server)
         .post('/healthz')
         .expect(404)
@@ -76,7 +76,7 @@ describe('Testing with koa', () => {
   })
 
   it('Returns a 200 when healthz route is found', async () => {
-    await withServer(router(healthz), async server => {
+    await withServer(router(healthz), async (server) => {
       const reply = await request(server)
         .get('/healthz')
         .expect(200)
@@ -100,7 +100,7 @@ describe('Testing with koa', () => {
   it("Returns a 200 when the healthz route is found but it's the second in the list of routes", async () => {
     await withServer(
       router(readyz, healthz),
-      async server => {
+      async (server) => {
         const reply = await request(server)
           .get('/healthz')
           .expect(200)
@@ -114,7 +114,7 @@ describe('Testing with koa', () => {
   it('Returns a 201 when the readyz route is found', async () => {
     await withServer(
       router(readyz, healthz),
-      async server => {
+      async (server) => {
         const reply = await request(server)
           .get('/readyz')
           .expect(201)
@@ -142,7 +142,7 @@ describe('Testing with koa', () => {
   )
 
   it("Returns a 400 when the route matches but the params don't validate", async () => {
-    await withServer(router(userId), async server => {
+    await withServer(router(userId), async (server) => {
       const reply = await request(server)
         .get('/user/dog')
         .expect(400)
@@ -153,7 +153,7 @@ describe('Testing with koa', () => {
   })
 
   it('Returns a 200 when the route and params match', async () => {
-    await withServer(router(userId), async server => {
+    await withServer(router(userId), async (server) => {
       await request(server).get('/user/123').expect(200)
     })
   })
@@ -174,7 +174,7 @@ describe('Testing with koa', () => {
   )
 
   it('Returns a 200 when the route and query params match', async () => {
-    await withServer(router(userQuery), async server => {
+    await withServer(router(userQuery), async (server) => {
       await request(server).get('/user?id=123').expect(200)
     })
   })
@@ -196,7 +196,7 @@ describe('Testing with koa', () => {
   )
 
   it('Returns a 200 when the route and headers match', async () => {
-    await withServer(router(userHeader), async server => {
+    await withServer(router(userHeader), async (server) => {
       await request(server)
         .get('/user')
         .set({ session: '123' })
@@ -225,7 +225,7 @@ describe('Testing with koa', () => {
   )
 
   it('Returns a 200 when the route and data matches', async () => {
-    await withServer(router(userPost), async server => {
+    await withServer(router(userPost), async (server) => {
       await request(server)
         .post('/user')
         .send({ sessionId: 123, dog: true })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -56,7 +56,7 @@ const healthz = routeWithHandler(
 
 describe('Testing with koa', () => {
   it('Returns a 404 when no routes are found', async () => {
-    await withServer(router(healthz), async (server) => {
+    await withServer(router(healthz), async server => {
       const reply = await request(server)
         .get('/')
         .expect(404)
@@ -66,7 +66,7 @@ describe('Testing with koa', () => {
   })
 
   it('Returns a 404 when method does not match for healthz route', async () => {
-    await withServer(router(healthz), async (server) => {
+    await withServer(router(healthz), async server => {
       const reply = await request(server)
         .post('/healthz')
         .expect(404)
@@ -76,13 +76,13 @@ describe('Testing with koa', () => {
   })
 
   it('Returns a 200 when healthz route is found', async () => {
-    await withServer(router(healthz), async (server) => {
+    await withServer(router(healthz), async server => {
       const reply = await request(server)
         .get('/healthz')
         .expect(200)
 
       expect(reply.status).toEqual(200)
-      expect(reply.text).toEqual('Found')
+      expect(reply.text).toEqual('OK')
     })
   })
 
@@ -100,13 +100,27 @@ describe('Testing with koa', () => {
   it("Returns a 200 when the healthz route is found but it's the second in the list of routes", async () => {
     await withServer(
       router(readyz, healthz),
-      async (server) => {
+      async server => {
         const reply = await request(server)
           .get('/healthz')
           .expect(200)
 
         expect(reply.status).toEqual(200)
-        expect(reply.text).toEqual('Found')
+        expect(reply.text).toEqual('OK')
+      }
+    )
+  })
+
+  it('Returns a 201 when the readyz route is found', async () => {
+    await withServer(
+      router(readyz, healthz),
+      async server => {
+        const reply = await request(server)
+          .get('/readyz')
+          .expect(201)
+
+        expect(reply.status).toEqual(201)
+        expect(reply.text).toEqual('OK')
       }
     )
   })
@@ -128,7 +142,7 @@ describe('Testing with koa', () => {
   )
 
   it("Returns a 400 when the route matches but the params don't validate", async () => {
-    await withServer(router(userId), async (server) => {
+    await withServer(router(userId), async server => {
       const reply = await request(server)
         .get('/user/dog')
         .expect(400)
@@ -139,7 +153,7 @@ describe('Testing with koa', () => {
   })
 
   it('Returns a 200 when the route and params match', async () => {
-    await withServer(router(userId), async (server) => {
+    await withServer(router(userId), async server => {
       await request(server).get('/user/123').expect(200)
     })
   })
@@ -160,7 +174,7 @@ describe('Testing with koa', () => {
   )
 
   it('Returns a 200 when the route and query params match', async () => {
-    await withServer(router(userQuery), async (server) => {
+    await withServer(router(userQuery), async server => {
       await request(server).get('/user?id=123').expect(200)
     })
   })
@@ -182,7 +196,7 @@ describe('Testing with koa', () => {
   )
 
   it('Returns a 200 when the route and headers match', async () => {
-    await withServer(router(userHeader), async (server) => {
+    await withServer(router(userHeader), async server => {
       await request(server)
         .get('/user')
         .set({ session: '123' })
@@ -211,7 +225,7 @@ describe('Testing with koa', () => {
   )
 
   it('Returns a 200 when the route and data matches', async () => {
-    await withServer(router(userPost), async (server) => {
+    await withServer(router(userPost), async server => {
       await request(server)
         .post('/user')
         .send({ sessionId: 123, dog: true })

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ export const router = (
     // create NE array of handlers by prepending the first one
     A.prepend(routeHandler),
     // pass each one the route info
-    NE.map(routeHandler =>
+    NE.map((routeHandler) =>
       runRouteWithHandler(routeHandler)({
         url,
         method,

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,28 +48,29 @@ export const router = (
   const rawHeaders = ctx.request.headers
   const rawData = (ctx.request as any).body
 
-  const neHandlers = pipe(
+  const tryAllRoutes = pipe(
+    // all route handlers but the first
     routeHandlers,
-    A.prepend(routeHandler)
-  )
-
-  const allRoutesRun = pipe(
-    neHandlers,
-    NE.map((routeHandler) =>
+    // create NE array of handlers by prepending the first one
+    A.prepend(routeHandler),
+    // pass each one the route info
+    NE.map(routeHandler =>
       runRouteWithHandler(routeHandler)({
         url,
         method,
         rawData,
         rawHeaders,
       })
-    )
+    ),
+    // run each one in turn till one matches
+    neAltMany
   )
 
-  const result = await neAltMany(allRoutesRun)()
+  const result = await tryAllRoutes()
 
   if (E.isRight(result)) {
-    ctx.response.status = 200
-    ctx.response.body = 'Found'
+    ctx.response.status = result.right.code
+    ctx.response.body = result.right.data
 
     return
   } else {


### PR DESCRIPTION
We did not actually return the result of the endpoint, now we do.