### PR TITLE
Tidy up responses ready for openapi

### DIFF
--- a/src/Decoder.ts
+++ b/src/Decoder.ts
@@ -30,22 +30,3 @@ export const and = <
   }
   return { type: 'NoDecoder' }
 }
-
-export const or = <InputA, InputB>(
-  a: Decoder<InputA>,
-  b: Decoder<InputB>
-): Decoder<InputA | InputB> => {
-  if (a.type !== 'Decoder' && b.type === 'Decoder') {
-    return b as Decoder<InputA | InputB>
-  }
-  if (a.type === 'Decoder' && b.type !== 'Decoder') {
-    return a as Decoder<InputA | InputB>
-  }
-  if (a.type === 'Decoder' && b.type === 'Decoder') {
-    return {
-      type: 'Decoder',
-      decoder: t.union([a.decoder, b.decoder]),
-    }
-  }
-  return { type: 'NoDecoder' }
-}

--- a/src/Encoder.ts
+++ b/src/Encoder.ts
@@ -1,37 +1,21 @@
 import * as t from 'io-ts'
 
+type Metadata = {
+  example?: unknown
+  description?: string
+}
+
+type MetadataByResponse = Record<number, Metadata>
+
 export type Encoder<Input, Output> =
   | {
       type: 'Encoder'
       encoder: t.Type<Input, Output, unknown>
+      metadata: MetadataByResponse
     }
   | { type: 'NoEncoder' }
 
 type GenericRec = Record<string, unknown>
-
-export const and = <
-  InputA extends GenericRec,
-  OutputA extends GenericRec,
-  InputB extends GenericRec,
-  OutputB extends GenericRec
->(
-  a: Encoder<InputA, OutputB>,
-  b: Encoder<InputB, OutputB>
-): Encoder<InputA & InputB, OutputA & OutputB> => {
-  if (a.type !== 'Encoder' && b.type === 'Encoder') {
-    return b as Encoder<InputA & InputB, OutputA & OutputB>
-  }
-  if (a.type === 'Encoder' && b.type !== 'Encoder') {
-    return a as Encoder<InputA & InputB, OutputA & OutputB>
-  }
-  if (a.type === 'Encoder' && b.type === 'Encoder') {
-    return {
-      type: 'Encoder',
-      encoder: t.intersection([a.encoder, b.encoder]),
-    } as Encoder<InputA & InputB, OutputA & OutputB>
-  }
-  return { type: 'NoEncoder' }
-}
 
 export const or = <InputA, OutputA, InputB, OutputB>(
   a: Encoder<InputA, OutputA>,
@@ -47,6 +31,7 @@ export const or = <InputA, OutputA, InputB, OutputB>(
     return {
       type: 'Encoder',
       encoder: t.union([a.encoder, b.encoder]),
+      metadata: { ...a.metadata, ...b.metadata },
     }
   }
   return { type: 'NoEncoder' }

--- a/src/Handler.test.ts
+++ b/src/Handler.test.ts
@@ -15,13 +15,14 @@ import { makeRoute } from './makeRoute'
 
 describe('test the handlers', () => {
   it('uses the healthz handler successfully', async () => {
-    const responseD = t.type({
-      code: t.literal(200),
-      data: t.literal('OK'),
-    })
+    const responseD = t.literal('OK')
 
     const healthz = routeWithTaskHandler(
-      makeRoute(get, lit('healthz'), response(responseD)),
+      makeRoute(
+        get,
+        lit('healthz'),
+        response(200, responseD)
+      ),
 
       () => {
         return T.of(respond(200, 'OK' as const))
@@ -47,20 +48,13 @@ describe('test the handlers', () => {
       horse: 23,
     }
 
-    const dogResponse = t.union([
-      t.type({
-        code: t.literal(200),
-        data: t.array(t.string),
-      }),
-      t.type({ code: t.literal(400), data: t.string }),
-    ])
-
     const dogAgesHandler = routeWithTaskHandler(
       makeRoute(
         get,
         lit('dogs'),
         param('age', numberDecoder),
-        response(dogResponse)
+        response(200, t.array(t.string)),
+        response(400, t.string)
       ),
       ({ params: { age } }) => {
         const matchingDogs = Object.entries(dogAges).filter(

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -19,13 +19,14 @@ import {
   respond,
 } from './index'
 
-const healthzDecoder = t.type({
-  code: t.literal(200),
-  data: t.literal('OK'),
-})
+const healthzDecoder = t.literal('OK')
 
 const healthz = routeWithTaskHandler(
-  makeRoute(get, lit('healthz'), response(healthzDecoder)),
+  makeRoute(
+    get,
+    lit('healthz'),
+    response(200, healthzDecoder)
+  ),
 
   () => T.of(respond(200, 'OK' as const))
 )
@@ -71,13 +72,14 @@ describe('testing with koa', () => {
     )
   })
 
-  const readyzDecoder = t.type({
-    code: t.literal(201),
-    data: t.literal('OK'),
-  })
+  const readyzDecoder = t.literal('OK')
 
   const readyz = routeWithTaskHandler(
-    makeRoute(get, lit('readyz'), response(readyzDecoder)),
+    makeRoute(
+      get,
+      lit('readyz'),
+      response(201, readyzDecoder)
+    ),
 
     () => T.of(respond(201, 'OK' as const))
   )
@@ -115,12 +117,8 @@ describe('testing with koa', () => {
       get,
       lit('user'),
       param('id', numberDecoder),
-      response(
-        t.type({ code: t.literal(200), data: t.number })
-      ),
-      response(
-        t.type({ code: t.literal(400), data: t.string })
-      )
+      response(200, t.number),
+      response(400, t.string)
     ),
 
     ({ params: { id } }) => T.of(respond(200, id))
@@ -156,9 +154,7 @@ describe('testing with koa', () => {
     makeRoute(
       get,
       lit('user'),
-      response(
-        t.type({ code: t.literal(200), data: t.number })
-      ),
+      response(200, t.number),
       query(t.type({ id: numberDecoder }))
     ),
 
@@ -181,9 +177,7 @@ describe('testing with koa', () => {
     makeRoute(
       get,
       lit('user'),
-      response(
-        t.type({ code: t.literal(200), data: t.number })
-      ),
+      response(200, t.number),
       headers(t.type({ session: numberDecoder }))
     ),
 
@@ -207,9 +201,7 @@ describe('testing with koa', () => {
     makeRoute(
       post,
       lit('user'),
-      response(
-        t.type({ code: t.literal(200), data: t.number })
-      ),
+      response(200, t.number),
       data(
         t.type({
           sessionId: t.number,

--- a/src/routeCombinators.ts
+++ b/src/routeCombinators.ts
@@ -19,11 +19,33 @@ export const lit = (literal: string): Route => ({
   parts: [routeLiteral(literal)],
 })
 
-export const response = <ResponseInput, ResponseOutput>(
-  encoder: t.Type<ResponseInput, ResponseOutput, unknown>
-): Route<ResponseInput, ResponseOutput> => ({
+export const response = <
+  StatusCode extends number,
+  ResponseInput,
+  ResponseOutput
+>(
+  statusCode: StatusCode,
+  encoder: t.Type<ResponseInput, ResponseOutput, unknown>,
+  example?: ResponseOutput,
+  description?: string
+): Route<
+  { code: StatusCode; data: ResponseInput },
+  { code: StatusCode; data: ResponseOutput }
+> => ({
   ...emptyRoute,
-  responseEncoder: { type: 'Encoder', encoder },
+  responseEncoder: {
+    type: 'Encoder',
+    encoder: t.type({
+      code: t.literal(statusCode),
+      data: encoder,
+    }),
+    metadata: {
+      [statusCode]: {
+        example,
+        description,
+      },
+    },
+  },
 })
 
 export const param = <ParamName extends string, Param>(


### PR DESCRIPTION
This separates out the status code from the encoder for a response. This

a) makes it less messy looking
b) allows us to collect metadata for OpenAPI
