### PR TITLE
Interpolated string routes constructor

### DIFF
--- a/src/Route.ts
+++ b/src/Route.ts
@@ -7,7 +7,7 @@ import * as E from './Encoder'
 
 export type GenericRec = Record<string, unknown>
 
-export type EmptyRec = Record<string, never>
+export type EmptyRec = Record<never, never>
 
 // Route is the basic type under everything.
 // It is designed Monoidally so a Route is made by combining multiple Routes

--- a/src/makeRoute.ts
+++ b/src/makeRoute.ts
@@ -1,6 +1,6 @@
 import { AnyRoute, CombinedRoute, combine } from './Route'
 
-type CR<A, B> = CombinedRoute<A, B>
+export type CR<A, B> = CombinedRoute<A, B>
 
 export function makeRoute<A extends AnyRoute>(a: A): A
 export function makeRoute<

--- a/src/routeCombinators.test.ts
+++ b/src/routeCombinators.test.ts
@@ -1,8 +1,12 @@
-import { routes, param } from './routeCombinators'
+import { lit, routes, param } from './routeCombinators'
 import { emptyRoute } from './Route'
 import { routeLiteral, routeParam } from './RouteItem'
 import * as t from 'io-ts'
 import { makeRoute } from './makeRoute'
+
+// this function won't type check if Typescript doesn't think the two args
+// are the same
+const areTypeEqual = <A>(a: A, b: A) => true
 
 describe('routes', () => {
   it('has no interpolated', () => {
@@ -34,6 +38,7 @@ describe('routes', () => {
       expect(result1.paramDecoder).toEqual(
         idParam.paramDecoder
       )
+      expect(areTypeEqual(result1, idParam)).toBeTruthy()
     })
 
     it('two items', () => {
@@ -45,6 +50,7 @@ describe('routes', () => {
       expect(JSON.stringify(result2.paramDecoder)).toEqual(
         JSON.stringify(expected.paramDecoder)
       )
+      expect(areTypeEqual(result2, expected)).toBeTruthy()
     })
     it('two items, no slash', () => {
       const result3 = routes`${idParam}${nameParam}`
@@ -55,10 +61,18 @@ describe('routes', () => {
       expect(JSON.stringify(result3.paramDecoder)).toEqual(
         JSON.stringify(expected.paramDecoder)
       )
+      expect(areTypeEqual(result3, expected)).toBeTruthy()
     })
   })
 
   it('interleaves literals and params correctly', () => {
+    const equivalentRoute = makeRoute(
+      lit('home'),
+      lit('users'),
+      param('userId', t.string),
+      lit('thanks')
+    )
+
     const expected = [
       routeLiteral('home'),
       routeLiteral('users'),
@@ -69,6 +83,9 @@ describe('routes', () => {
     const userId = param('userId', t.string)
     const result = routes`home/users/${userId}/thanks`
 
+    expect(
+      areTypeEqual(result, equivalentRoute)
+    ).toBeTruthy()
     expect(result.parts).toEqual(expected)
   })
 })

--- a/src/routeCombinators.test.ts
+++ b/src/routeCombinators.test.ts
@@ -1,0 +1,74 @@
+import { routes, param } from './routeCombinators'
+import { emptyRoute } from './Route'
+import { routeLiteral, routeParam } from './RouteItem'
+import * as t from 'io-ts'
+import { makeRoute } from './makeRoute'
+
+describe('routes', () => {
+  it('has no interpolated', () => {
+    expect(routes``).toEqual({
+      ...emptyRoute,
+      parts: [],
+    })
+    expect(routes`/`).toEqual({
+      ...emptyRoute,
+      parts: [],
+    })
+    expect(routes`dog`).toEqual({
+      ...emptyRoute,
+      parts: [routeLiteral('dog')],
+    })
+    expect(routes`dog/log`).toEqual({
+      ...emptyRoute,
+      parts: [routeLiteral('dog'), routeLiteral('log')],
+    })
+  })
+  describe('has only interpolated items', () => {
+    const idParam = param('id', t.string)
+    const nameParam = param('name', t.string)
+
+    it('one item', () => {
+      const result1 = routes`${idParam}`
+      expect(result1.parts).toHaveLength(1)
+      expect(result1.parts).toEqual(idParam.parts)
+      expect(result1.paramDecoder).toEqual(
+        idParam.paramDecoder
+      )
+    })
+
+    it('two items', () => {
+      const result2 = routes`${idParam}/${nameParam}`
+      const expected = makeRoute(idParam, nameParam)
+
+      expect(result2.parts).toHaveLength(2)
+      expect(result2.parts).toEqual(expected.parts)
+      expect(JSON.stringify(result2.paramDecoder)).toEqual(
+        JSON.stringify(expected.paramDecoder)
+      )
+    })
+    it('two items, no slash', () => {
+      const result3 = routes`${idParam}${nameParam}`
+      const expected = makeRoute(idParam, nameParam)
+
+      expect(result3.parts).toHaveLength(2)
+      expect(result3.parts).toEqual(expected.parts)
+      expect(JSON.stringify(result3.paramDecoder)).toEqual(
+        JSON.stringify(expected.paramDecoder)
+      )
+    })
+  })
+
+  it('interleaves literals and params correctly', () => {
+    const expected = [
+      routeLiteral('home'),
+      routeLiteral('users'),
+      routeParam('userId'),
+      routeLiteral('thanks'),
+    ]
+
+    const userId = param('userId', t.string)
+    const result = routes`home/users/${userId}/thanks`
+
+    expect(result.parts).toEqual(expected)
+  })
+})

--- a/src/routeCombinators.ts
+++ b/src/routeCombinators.ts
@@ -1,9 +1,19 @@
 import * as t from 'io-ts'
 import * as O from 'fp-ts/Option'
 
-import { routeLiteral, routeParam } from './RouteItem'
-import { EmptyRec, Route, emptyRoute } from './Route'
+import {
+  RouteItem,
+  routeLiteral,
+  routeParam,
+} from './RouteItem'
+import {
+  AnyRoute,
+  EmptyRec,
+  Route,
+  emptyRoute,
+} from './Route'
 import * as E from './Encoder'
+import { CR, makeRoute } from './makeRoute'
 
 export const get: Route = {
   ...emptyRoute,
@@ -19,6 +29,93 @@ export const lit = (literal: string): Route => ({
   ...emptyRoute,
   parts: [routeLiteral(literal)],
 })
+
+export function routes(parts: TemplateStringsArray): Route
+export function routes<A extends AnyRoute>(
+  parts: TemplateStringsArray,
+  a: A
+): A
+export function routes<
+  A extends AnyRoute,
+  B extends AnyRoute
+>(parts: TemplateStringsArray, a: A, b: B): CR<A, B>
+export function routes<
+  A extends AnyRoute,
+  B extends AnyRoute,
+  C extends AnyRoute
+>(
+  parts: TemplateStringsArray,
+  a: A,
+  b: B,
+  c: C
+): CR<CR<A, B>, C>
+export function routes<
+  A extends AnyRoute,
+  B extends AnyRoute,
+  C extends AnyRoute,
+  D extends AnyRoute
+>(
+  parts: TemplateStringsArray,
+  a: A,
+  b: B,
+  c: C,
+  d: D
+): CR<CR<CR<A, B>, C>, D>
+export function routes<
+  A extends AnyRoute,
+  B extends AnyRoute,
+  C extends AnyRoute,
+  D extends AnyRoute,
+  E extends AnyRoute
+>(
+  parts: TemplateStringsArray,
+  a: A,
+  b: B,
+  c: C,
+  d: D,
+  e: E
+): CR<CR<CR<CR<A, B>, C>, D>, E>
+export function routes<
+  A extends AnyRoute,
+  B extends AnyRoute,
+  C extends AnyRoute,
+  D extends AnyRoute,
+  E extends AnyRoute,
+  F extends AnyRoute
+>(
+  parts: TemplateStringsArray,
+  a: A,
+  b: B,
+  c: C,
+  d: D,
+  e: E,
+  f: F
+): CR<CR<CR<CR<CR<A, B>, C>, D>, E>, F>
+
+export function routes(
+  parts: TemplateStringsArray,
+  a = emptyRoute,
+  b = emptyRoute,
+  c = emptyRoute,
+  d = emptyRoute,
+  e = emptyRoute,
+  f = emptyRoute
+): unknown {
+  const literals: RouteItem[][] = parts.map(part =>
+    part
+      .split('/')
+      .filter(a => a.length > 0)
+      .map(routeLiteral)
+  )
+  const params = [a, b, c, d, e, f]
+
+  // for each item in literals, smash another param after it
+  return literals.reduce((all, lits, index) => {
+    const nextParam = params[index]
+    const literalRoute = { ...emptyRoute, parts: lits }
+    return makeRoute(all, literalRoute, nextParam)
+  }, emptyRoute)
+}
 
 export const response = <
   StatusCode extends number,


### PR DESCRIPTION
Absolutely livid this worked tbf.

`a` and `b` below should be equivalent in both type and behaviour.

```typescript
const id = param('id',t.string)

const a = routes`egg/log/${id}/thanks`

const b = makeRoute(lit('egg'),lit('log'), id, lit('thanks'))
```


